### PR TITLE
Refactor test_installer to run it at the begging of unit-tests

### DIFF
--- a/Dockerfile-forTest
+++ b/Dockerfile-forTest
@@ -53,6 +53,7 @@ RUN \
     unzip test/data/employees.zip -o -d test/data && \
     mysql -u root -proot employees < test/data/employees.sql && \
     pip install -r requirements/common.txt && \
+    pip install -r requirements/test.txt && \
     bash usagi-installer --data-store test/psql_mysql/search.ini && \
     # stop services
     rc-service mariadb stop && \

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,1 @@
+pytest-ordering


### PR DESCRIPTION
This PR refactors `test/test_installer.py` which reinitializes Solr with a test configuration, therefore, we should run the script at the begging of unit-tests. 

For the ordering problem, I introduced https://pytest-ordering.readthedocs.io/en/develop/ with which we can specify the order of unit-tests. 

